### PR TITLE
Display threshold indicator and update UI color based on threshold status (issue #5)

### DIFF
--- a/implementation/src/components/TotalAndThreshold.tsx
+++ b/implementation/src/components/TotalAndThreshold.tsx
@@ -5,11 +5,17 @@ interface TotalAndThresholdProps {
   threshold: number;
 }
 
-const TotalAndThreshold: React.FC<TotalAndThresholdProps> = ({ total, threshold }) => (
-  <div className="total-threshold">
-    <div>Today: <strong>{total} ml</strong></div>
-    <div>Threshold: <strong>{threshold} ml</strong></div>
-  </div>
-);
+
+const TotalAndThreshold: React.FC<TotalAndThresholdProps> = ({ total, threshold }) => {
+  const status = total >= threshold ? 'over' : total >= threshold * 0.8 ? 'near' : 'under';
+  return (
+    <div className="total-threshold">
+      <div>
+        Today: <strong className={`threshold-status ${status}`}>{total} ml</strong>
+      </div>
+      <div>Threshold: <strong>{threshold} ml</strong></div>
+    </div>
+  );
+};
 
 export default TotalAndThreshold;

--- a/implementation/src/styles.css
+++ b/implementation/src/styles.css
@@ -41,6 +41,16 @@ body {
   justify-content: space-between;
   margin-bottom: 1rem;
 }
+.threshold-status.under {
+  color: #0077ff;
+}
+.threshold-status.near {
+  color: #ff9800;
+}
+.threshold-status.over {
+  color: #e53935;
+  font-weight: bold;
+}
 .bar-chart {
   display: flex;
   align-items: flex-end;


### PR DESCRIPTION
This PR implements the threshold indicator and UI color feedback for HydroTracker as described in issue #5.

**Tasks completed:**
- [x] Implement threshold comparison logic
- [x] Update UI color based on threshold status
- [x] README up to date (if needed)
- [x] Review guidance in PR description

## Review Guidance
- **Threshold Indicator:**
  - The "Today" value changes color based on how close it is to the threshold:
    - Blue: under 80% of threshold
    - Orange: 80% or more, but below threshold
    - Red: at or above threshold
- **Testing:**
  1. Start the app as described in the README.
  2. Add intakes and observe the color change as you approach and exceed the threshold.
- **Code:**
  - Review `TotalAndThreshold.tsx` and `styles.css` for logic and styling.

---
Closes #5.

/assign @copilot